### PR TITLE
Fix argument order for Contract constructor.

### DIFF
--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -26,8 +26,9 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     abi_file_path, output_dir, line_length = parse_arguments(argv)
 
-    # Set up the output directory
+    # Create/clear the directory
     setup_directory(output_dir)
+
     # List to store all JSON files to be processed
     json_files_to_process = []
 

--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -18,38 +18,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     ---------
     abi_file_path : str
         Path to the abi JSON file.
-    output_dr: str
+    output_dir: str
         Path to the directory where files will be generated.
     line_length : int
         Optional argument for the output file's maximum line length. Defaults to 80.
     """
-    parser = argparse.ArgumentParser(
-        description="Generates class files for a given abi."
-    )
-    parser.add_argument(
-        "abi_file_path",
-        help="Path to the abi JSON file or directory containing multiple JSON files.",
-    )
 
-    parser.add_argument(
-        "--output_dir",
-        default="pypechain_types",
-        help="Path to the directory where files will be generated. Defaults to pypechain_types.",
-    )
-    parser.add_argument(
-        "--line_length",
-        type=int,
-        default=80,
-        help="Optional argument for the output file's maximum line length. Defaults to 80.",
-    )
-
-    # If no arguments were passed, display the help message and exit
-    if len(sys.argv) == 1:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
-
-    args: Args = namespace_to_args(parser.parse_args(argv))
-    abi_file_path, output_dir, line_length = args
+    abi_file_path, output_dir, line_length = parse_arguments(argv)
 
     # Set up the output directory
     setup_directory(output_dir)
@@ -100,6 +75,36 @@ def namespace_to_args(namespace: argparse.Namespace) -> Args:
         output_dir=namespace.output_dir,
         line_length=namespace.line_length,
     )
+
+def parse_arguments(argv: Sequence[str] | None = None) -> Args:
+    """Parses input arguments"""
+    parser = argparse.ArgumentParser(
+        description="Generates class files for a given abi."
+    )
+    parser.add_argument(
+        "abi_file_path",
+        help="Path to the abi JSON file or directory containing multiple JSON files.",
+    )
+
+    parser.add_argument(
+        "--output_dir",
+        default="pypechain_types",
+        help="Path to the directory where files will be generated. Defaults to pypechain_types.",
+    )
+    parser.add_argument(
+        "--line_length",
+        type=int,
+        default=80,
+        help="Optional argument for the output file's maximum line length. Defaults to 80.",
+    )
+
+    # If no arguments were passed, display the help message and exit
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    return namespace_to_args(parser.parse_args(argv))
+
 
 
 if __name__ == "__main__":

--- a/pypechain/render/contract.py
+++ b/pypechain/render/contract.py
@@ -11,6 +11,7 @@ from pypechain.utilities.abi import (
     get_output_names,
     is_abi_constructor,
     is_abi_function,
+    load_abi_from_file,
 )
 from pypechain.utilities.format import capitalize_first_letter_only
 from pypechain.utilities.sort import get_intersection_and_unique
@@ -99,12 +100,17 @@ def render_contract_file(
                         unique_input_names,
                     ) = get_intersection_and_unique(function_datas[name]["input_names"])
                     function_datas[name]["required_input_names"] = shared_input_names
+
                     function_datas[name]["optional_input_names"] = unique_input_names
+
+    abi = load_abi_from_file(abi_file_path)
 
     # Render the template
     return contract_template.render(
+        abi=abi,
         contract_name=contract_name,
         functions=list(function_datas.values()),
         # TODO: use this data to add a typed constructor
         constructor=constructor_data,
+
     )

--- a/pypechain/templates/contract.jinja2
+++ b/pypechain/templates/contract.jinja2
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from eth_typing import ChecksumAddress
+from web3.types import ABI
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound
 
@@ -85,11 +86,14 @@ class {{contract_name}}ContractFunctions(ContractFunctions):
     {{function.name}}: {{contract_name}}{{function.capitalized_name}}ContractFunction
 {% endfor %}
 
+{{contract_name | lower}}_abi: ABI = {{abi}}
+
 class {{contract_name}}Contract(Contract):
     """A web3.py Contract class for the {{contract_name}} contract."""
 
-    def __init__(self, address: ChecksumAddress | None = None, abi=Any) -> None:
-        self.abi = abi
+    abi: ABI = {{contract_name | lower}}_abi
+
+    def __init__(self, address: ChecksumAddress | None = None) -> None:
         # TODO: make this better, shouldn't initialize to the zero address, but the Contract's init
         # function requires an address.
         self.address = address if address else cast(ChecksumAddress, "0x0000000000000000000000000000000000000000")

--- a/pypechain/utilities/abi.py
+++ b/pypechain/utilities/abi.py
@@ -455,6 +455,7 @@ def load_abi_from_file(file_path: Path) -> ABI:
         return json.load(file)["abi"]
 
 
+# TODO: pass abi, not file_path
 def get_abi_items(file_path: Path) -> list[ABIElement]:
     """Gets all of the functions and events in the ABI.
 


### PR DESCRIPTION
We were trying to pass the abi after an optional address.  The abi doesn't actually need to be passed in at all since we are already working with it to create the codegened files.  Instead, set the abi and just pass along an optional address to the contract's super().