### PR TITLE
don't initialize address

### DIFF
--- a/pypechain/templates/contract.jinja2
+++ b/pypechain/templates/contract.jinja2
@@ -94,10 +94,6 @@ class {{contract_name}}Contract(Contract):
     abi: ABI = {{contract_name | lower}}_abi
 
     def __init__(self, address: ChecksumAddress | None = None) -> None:
-        # TODO: make this better, shouldn't initialize to the zero address, but the Contract's init
-        # function requires an address.
-        self.address = address if address else cast(ChecksumAddress, "0x0000000000000000000000000000000000000000")
-
         try:
             # Initialize parent Contract class
             super().__init__(address=address)


### PR DESCRIPTION
I'm not sure why this was happening before, but we don't need to do this, simply call super's init with the optional address.