### PR TITLE
Add imports to __init__.py

### DIFF
--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -12,6 +12,7 @@ from web3.exceptions import NoABIFunctionsFound
 
 from pypechain.render.main import render_files
 from pypechain.utilities.file import write_string_to_file
+from pypechain.utilities.format import apply_black_formatting
 from pypechain.utilities.templates import get_jinja_env
 
 
@@ -58,15 +59,16 @@ def main(argv: Sequence[str] | None = None) -> None:
             raise err
 
     # Finally, render the __init__.py file
-    render_init_file(output_dir, file_names)
+    render_init_file(output_dir, file_names, line_length)
 
 
-def render_init_file(output_dir: str, file_names: list[str]):
+def render_init_file(output_dir: str, file_names: list[str], line_length):
     """Creates an __init__.py file that imports all other files."""
     env = get_jinja_env()
     init_template = env.get_template("init.py.jinja2")
     init_code = init_template.render(file_names=file_names)
-    write_string_to_file(f"{output_dir}/__init__.py", init_code)
+    formatted_init_code = apply_black_formatting(init_code, line_length)
+    write_string_to_file(f"{output_dir}/__init__.py", formatted_init_code)
 
 
 def gather_json_files(directory: str) -> list:

--- a/pypechain/render/main.py
+++ b/pypechain/render/main.py
@@ -3,14 +3,13 @@
 import os
 from pathlib import Path
 
-
 from pypechain.render.contract import render_contract_file
 from pypechain.render.types import render_types_file
 from pypechain.utilities.file import write_string_to_file
 from pypechain.utilities.format import apply_black_formatting
 
 
-def render_files(abi_file_path: str, output_dir: str, line_length: int) -> None:
+def render_files(abi_file_path: str, output_dir: str, line_length: int) -> list[str]:
     """Processes a single JSON file to generate class and types files."""
 
     # get names
@@ -22,12 +21,19 @@ def render_files(abi_file_path: str, output_dir: str, line_length: int) -> None:
 
     # render the code
     rendered_contract_code = render_contract_file(contract_name, file_path)
+    # TODO: if there are no types generated, then this should return None
     rendered_types_code = render_types_file(contract_name, file_path)
 
-    # Format the generated code using Black
+    file_names: list[str] = []
+    # Format the generated code using Black and rite the code to file
     formatted_contract_code = apply_black_formatting(rendered_contract_code, line_length)
-    formatted_types_code = apply_black_formatting(rendered_types_code, line_length)
-
-    # Write the code to file
     write_string_to_file(f"{contract_path}Contract.py", formatted_contract_code)
-    write_string_to_file(f"{contract_path}Types.py", formatted_types_code)
+    file_names.append(f"{contract_name}Contract")
+
+    # TODO: write tests for this conditional write.
+    if rendered_types_code:
+        formatted_types_code = apply_black_formatting(rendered_types_code, line_length)
+        write_string_to_file(f"{contract_path}Types.py", formatted_types_code)
+        file_names.append(f"{contract_name}Types")
+
+    return file_names

--- a/pypechain/render/types.py
+++ b/pypechain/render/types.py
@@ -39,7 +39,7 @@ def render_types_file(contract_name: str, abi_file_path: Path) -> str | None:
     has_event_params = any(len(event["inputs"]) > 0 for event in events)
 
     if not has_events and not has_structs:
-        return
+        return None
 
     return types_template.render(
         contract_name=contract_name,

--- a/pypechain/render/types.py
+++ b/pypechain/render/types.py
@@ -1,4 +1,6 @@
 """Functions to render Python types from an abi usng a jinja2 template."""
+from __future__ import annotations
+
 from dataclasses import asdict
 from pathlib import Path
 
@@ -6,7 +8,7 @@ from pypechain.utilities.abi import get_events_for_abi, get_structs_for_abi, loa
 from pypechain.utilities.templates import get_jinja_env
 
 
-def render_types_file(contract_name: str, abi_file_path: Path) -> str:
+def render_types_file(contract_name: str, abi_file_path: Path) -> str | None:
     """Returns the serialized code of the types file to be generated.
 
     Arguments
@@ -33,7 +35,11 @@ def render_types_file(contract_name: str, abi_file_path: Path) -> str:
     structs = [asdict(struct) for struct in structs_list]
     events = [asdict(event) for event in get_events_for_abi(abi)]
     has_events = bool(events)
+    has_structs = bool(structs)
     has_event_params = any(len(event["inputs"]) > 0 for event in events)
+
+    if not has_events and not has_structs:
+        return
 
     return types_template.render(
         contract_name=contract_name,

--- a/pypechain/templates/init.py.jinja2
+++ b/pypechain/templates/init.py.jinja2
@@ -1,0 +1,5 @@
+"""Export all types from generated files."""
+
+{% for name in file_names -%}
+from .{{name}} import *
+{% endfor %}


### PR DESCRIPTION
Makes all the exports available at the top level.  Fixes #42 