### PR TITLE
Fix overloading for call() method

### DIFF
--- a/pypechain/templates/contract.py/base.py.jinja2
+++ b/pypechain/templates/contract.py/base.py.jinja2
@@ -15,19 +15,18 @@
 # pylint: disable=too-many-lines
 
 from __future__ import annotations
-from typing import Any, Tuple, Type, TypeVar, cast
-from typing_extensions import Self
+
 from dataclasses import fields, is_dataclass
+from typing import Any, Tuple, Type, TypeVar, cast
 
 from eth_typing import ChecksumAddress{% if has_bytecode %}, HexStr{% endif %}
 {% if has_bytecode %}from hexbytes import HexBytes{% endif %}
+{% if has_overloading %}from multimethod import multimethod {% endif %}
+from typing_extensions import Self
 from web3 import Web3
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
 from web3.exceptions import FallbackNotFound
 from web3.types import ABI, BlockIdentifier, CallOverride, TxParams
-{% if has_overloading %}
-from multimethod import multimethod
-{% endif %}
 {% if structs_for_abi|length > 0 %}from .{{contract_name}}Types import {{ structs_for_abi|join(', ')}}{% endif %}
 
 T = TypeVar("T")

--- a/pypechain/templates/contract.py/functions.py.jinja2
+++ b/pypechain/templates/contract.py/functions.py.jinja2
@@ -9,32 +9,31 @@ class {{contract_name}}{{function_data.capitalized_name}}ContractFunction(Contra
     # pylint: disable=function-redefined
 {%- endif -%}
 {% for signature_data in function_data.signature_datas %}
-{% if function_data.signature_datas|length > 1%}    @multimethod{% endif %}
+{% if function_data.has_overloading %}    @multimethod{% endif %}
     def __call__(self{% if signature_data.input_names_and_types %}, {{signature_data.input_names_and_types|join(', ')}}{% endif %}) -> "{{contract_name}}{{function_data.capitalized_name}}ContractFunction":{%- if function_data.signature_datas|length > 1 %} #type: ignore{% endif %}
         clone = super().__call__({{signature_data.input_names|join(', ')}})
         self.kwargs = clone.kwargs
         self.args = clone.args
         return self
-
-{% if function_data.signature_datas|length > 1%}    @multimethod{% endif %}
-    def call({%- if function_data.signature_datas|length > 1 %} #type: ignore{% endif %}
+{% endfor %}
+{% set output_types = function_data.signature_datas[0].output_types %}
+    def call(
         self,
         transaction: TxParams | None = None,
         block_identifier: BlockIdentifier = 'latest',
         state_override: CallOverride | None = None,
-        ccip_read_enabled: bool | None = None){% if signature_data.output_types|length == 1 %} -> {{signature_data.output_types[0]}}{% elif signature_data.output_types|length > 1%} -> tuple[{{signature_data.output_types|join(', ')}}]{% endif %}:
-            {% if signature_data.output_types|length == 1 %}"""returns {{signature_data.output_types[0]}}"""{% elif signature_data.output_types|length > 1%}"""returns ({{signature_data.output_types|join(', ')}})"""{% else %}"""No return value"""{% endif %}
-            raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
+        ccip_read_enabled: bool | None = None){% if function_data.has_multiple_return_signatures %} -> Any{% elif output_types|length == 1 %} -> {{output_types[0]}}{% elif output_types|length > 1%} -> tuple[{{output_types|join(', ')}}]{% else %} -> None{% endif %}:
+            {% if output_types|length == 1 %}"""returns {{output_types[0]}}"""{% elif output_types|length > 1%}"""returns ({{output_types|join(', ')}})"""{% else %}"""No return value"""{% endif %}
+            {% if output_types|length > 0 %}raw_values = {% endif %}super().call(transaction, block_identifier, state_override, ccip_read_enabled)
             # Define the expected return types from the smart contract call
-            return_types = {% if signature_data.output_types|length == 1 %}{{signature_data.output_types[0]}}{% elif signature_data.output_types|length > 1%}[{{signature_data.output_types|join(', ')}}]{% else %}None{% endif %}
-            {% if signature_data.output_types|length == 1 %}
-            return cast({{signature_data.output_types[0]}}, self._call(return_types, raw_values))
-            {% elif signature_data.output_types|length > 1 %}
-            return cast(tuple[{{signature_data.output_types|join(', ')}}], self._call(return_types, raw_values))
+            {% if output_types|length == 1 %}return_types = {{output_types[0]}}{% elif output_types|length > 1%}return_types = [{{output_types|join(', ')}}]{% endif %}
+            {% if output_types|length == 1 %}
+            return cast({{output_types[0]}}, self._call(return_types, raw_values))
+            {% elif output_types|length > 1 %}
+            return cast(tuple[{{output_types|join(', ')}}], self._call(return_types, raw_values))
             {% else %}
             return None
             {% endif %}
-{% endfor %}
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
         if isinstance(return_types, list):

--- a/pypechain/utilities/types.py
+++ b/pypechain/utilities/types.py
@@ -21,6 +21,8 @@ class FunctionData(TypedDict):
     name: str
     capitalized_name: str
     signature_datas: list[SignatureData]
+    has_overloading: bool
+    has_multiple_return_signatures: bool
 
 
 def solidity_to_python_type(solidity_type: str) -> str:

--- a/snapshots/expected_not_overloading.py
+++ b/snapshots/expected_not_overloading.py
@@ -20,9 +20,9 @@ class OverloadedBalanceOfContractFunction(ContractFunction):
             raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
             # Define the expected return types from the smart contract call
             return_types = int
-            
+
             return cast(int, self._call(return_types, raw_values))
-            
+
 
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
@@ -63,9 +63,9 @@ class OverloadedBalanceOfWhoContractFunction(ContractFunction):
             raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
             # Define the expected return types from the smart contract call
             return_types = bool
-            
+
             return cast(bool, self._call(return_types, raw_values))
-            
+
 
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
@@ -117,4 +117,3 @@ class OverloadedContractFunctions(ContractFunctions):
             decode_tuples=decode_tuples,
             function_identifier="balanceOfWho",
         )
-        

--- a/snapshots/expected_not_overloading.py
+++ b/snapshots/expected_not_overloading.py
@@ -20,10 +20,9 @@ class OverloadedBalanceOfContractFunction(ContractFunction):
             raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
             # Define the expected return types from the smart contract call
             return_types = int
-
+            
             return cast(int, self._call(return_types, raw_values))
-
-
+            
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
         if isinstance(return_types, list):
@@ -63,10 +62,9 @@ class OverloadedBalanceOfWhoContractFunction(ContractFunction):
             raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
             # Define the expected return types from the smart contract call
             return_types = bool
-
+            
             return cast(bool, self._call(return_types, raw_values))
-
-
+            
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
         if isinstance(return_types, list):
@@ -117,3 +115,4 @@ class OverloadedContractFunctions(ContractFunctions):
             decode_tuples=decode_tuples,
             function_identifier="balanceOfWho",
         )
+        

--- a/snapshots/expected_overloading.py
+++ b/snapshots/expected_overloading.py
@@ -11,29 +11,14 @@ class OverloadedBalanceOfContractFunction(ContractFunction):
         return self
 
     @multimethod
-    def call( #type: ignore
-        self,
-        transaction: TxParams | None = None,
-        block_identifier: BlockIdentifier = 'latest',
-        state_override: CallOverride | None = None,
-        ccip_read_enabled: bool | None = None) -> int:
-            """returns int"""
-            raw_values = super().call(transaction, block_identifier, state_override, ccip_read_enabled)
-            # Define the expected return types from the smart contract call
-            return_types = int
-            
-            return cast(int, self._call(return_types, raw_values))
-            
-
-    @multimethod
     def __call__(self, who: str) -> "OverloadedBalanceOfContractFunction": #type: ignore
         clone = super().__call__(who)
         self.kwargs = clone.kwargs
         self.args = clone.args
         return self
 
-    @multimethod
-    def call( #type: ignore
+
+    def call(
         self,
         transaction: TxParams | None = None,
         block_identifier: BlockIdentifier = 'latest',
@@ -46,7 +31,6 @@ class OverloadedBalanceOfContractFunction(ContractFunction):
             
             return cast(int, self._call(return_types, raw_values))
             
-
     def _call(self, return_types, raw_values):
         # cover case of multiple return values
         if isinstance(return_types, list):


### PR DESCRIPTION
In web3.py function construction and execution are separated:

```python
doSomething = deployed_contract.functions.doSomething(x)

result = doSomething.call()
```

This leads to problems if we want to provide typed return values from call() when doSomething() is overloaded:

```python
doSomething_x = deployed_contract.functions.doSomething(x)
doSomething_xy = deployed_contract.functions.doSomething(x,y)


result_x: int = doSomething_x.call()
result_xy: (int, int) = doSomething_xy.call()
```

For example, if x and xy versions have the same return signature, then we don't want to declare multiple call() methods.  If they do, then we want multple methods, but how do we know which one to call?  We can't.  We either have to provide multiple return signatures or have doSomething(x) and doSomething(x,y) return different call() methods.

A future improvement would be to change the invocation pattern to:
```python
call_options = CallOptions(block_number=1234)
result = deployed_contract.functions.doSomething(...args, call_options=call_options)
```

For now, if there are multiple return signatures we simply set the return signature to `Any` and avoid overloading call() all together.  This is probably a very edge case and can be improved in the future.  
