### PR TITLE
Remove 'return None' from call()

### DIFF
--- a/pypechain/templates/contract.py/functions.py.jinja2
+++ b/pypechain/templates/contract.py/functions.py.jinja2
@@ -31,8 +31,6 @@ class {{contract_name}}{{function_data.capitalized_name}}ContractFunction(Contra
             return cast({{output_types[0]}}, self._call(return_types, raw_values))
             {% elif output_types|length > 1 %}
             return cast(tuple[{{output_types|join(', ')}}], self._call(return_types, raw_values))
-            {% else %}
-            return None
             {% endif %}
     def _call(self, return_types, raw_values):
         # cover case of multiple return values


### PR DESCRIPTION
This is unecessary and causes pylint warnings.