### PR TITLE
Add deploy method to contracts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,7 +76,7 @@ def local_chain() -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
-def w3_init(local_chain) -> Web3:
+def w3_init(local_chain: str) -> Web3:
     """gets a Web3 instance connected to the local chain.
 
     Parameters
@@ -94,7 +94,7 @@ def w3_init(local_chain) -> Web3:
 
 
 @pytest.fixture(scope="function")
-def w3(w3_init) -> Web3:  # type: ignore
+def w3(w3_init: Web3) -> Web3:  # type: ignore
     """resets the anvil instance at the function level so each test gets a fresh chain.
 
     Parameters

--- a/pypechain/templates/contract.py/contract.py.jinja2
+++ b/pypechain/templates/contract.py/contract.py.jinja2
@@ -20,7 +20,21 @@ class {{contract_name}}Contract(Contract):
     functions: {{contract_name}}ContractFunctions
 
     @classmethod
-    def deploy(cls, w3: Web3, signer) -> Self:
+    def deploy(cls, w3: Web3, signer: ChecksumAddress) -> Self:
+        """Deploys and instance of the contract.
+
+        Parameters
+        ----------
+        w3 : Web3
+            A web3 instance.
+        signer : ChecksumAddress
+            The address to deploy the contract from.
+
+        Returns
+        -------
+        Self
+            A deployed instance of the contract.
+        """
         deployer = cls.factory(w3=w3)
         tx_hash = deployer.constructor().transact({"from": signer})
         tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)

--- a/pypechain/templates/contract.py/contract.py.jinja2
+++ b/pypechain/templates/contract.py/contract.py.jinja2
@@ -20,6 +20,14 @@ class {{contract_name}}Contract(Contract):
     functions: {{contract_name}}ContractFunctions
 
     @classmethod
+    def deploy(cls, w3: Web3, signer) -> Self:
+        deployer = cls.factory(w3=w3)
+        tx_hash = deployer.constructor().transact({"from": signer})
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        deployed_contract = deployer(address=tx_receipt.contractAddress) # type: ignore
+        return deployed_contract
+
+    @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = {{contract_name}}ContractFunctions({{contract_name | lower}}_abi, w3, None)

--- a/pypechain/test/overloading/test_overloading.py
+++ b/pypechain/test/overloading/test_overloading.py
@@ -23,17 +23,7 @@ class TestOverloading:
         All arguments are fixtures.
         """
 
-        # TODO: add the factory to the constructor so we can do:
-        # deployed_contract = MyContract(w3=w3, address=address)
-        # or:
-        # ContractDeployer =  MyContract(w3)
-        # deployed_contract = ContractDeployer.deploy(arg1, arg2)
-        deployer = OverloadedMethodsContract.factory(w3=w3)
-
-        # TODO: put this into a deploy method and add the address automatically
-        tx_hash = deployer.constructor().transact({"from": w3.eth.accounts[0]})
-        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-        deployed_contract = deployer(address=tx_receipt.contractAddress)
+        deployed_contract = OverloadedMethodsContract.deploy(w3=w3, signer=w3.eth.accounts[0])
 
         s = "test string"
         x = 1

--- a/pypechain/test/overloading/types/OverloadedMethodsContract.py
+++ b/pypechain/test/overloading/types/OverloadedMethodsContract.py
@@ -331,13 +331,13 @@ class OverloadedMethodsContract(Contract):
     functions: OverloadedMethodsContractFunctions
 
     @classmethod
-    def deploy(cls, w3: Web3, signer) -> Self:
-        """Deplays and instance of the contract.
+    def deploy(cls, w3: Web3, signer: ChecksumAddress) -> Self:
+        """Deploys and instance of the contract.
 
         Parameters
         ----------
         w3 : Web3
-            An instance of Web3
+            A web3 instance.
         signer : ChecksumAddress
             The address to deploy the contract from.
 

--- a/pypechain/test/overloading/types/OverloadedMethodsContract.py
+++ b/pypechain/test/overloading/types/OverloadedMethodsContract.py
@@ -23,15 +23,12 @@ from dataclasses import fields, is_dataclass
 from typing import Any, NamedTuple, Tuple, Type, TypeVar, cast, overload
 
 from eth_typing import ChecksumAddress, HexStr
-
 from hexbytes import HexBytes
 from typing_extensions import Self
 from web3 import Web3
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
-
 from web3.exceptions import FallbackNotFound
 from web3.types import ABI, BlockIdentifier, CallOverride, TxParams
-
 
 T = TypeVar("T")
 
@@ -332,6 +329,28 @@ class OverloadedMethodsContract(Contract):
             print("Fallback function not found. Continuing...")
 
     functions: OverloadedMethodsContractFunctions
+
+    @classmethod
+    def deploy(cls, w3: Web3, signer) -> Self:
+        """Deplays and instance of the contract.
+
+        Parameters
+        ----------
+        w3 : Web3
+            An instance of Web3
+        signer : ChecksumAddress
+            The address to deploy the contract from.
+
+        Returns
+        -------
+        Self
+            A deployed instance of the contract.
+        """
+        deployer = cls.factory(w3=w3)
+        tx_hash = deployer.constructor().transact({"from": signer})
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        deployed_contract = deployer(address=tx_receipt.contractAddress)  # type: ignore
+        return deployed_contract
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:

--- a/pypechain/test/return_types/test_returntypes.py
+++ b/pypechain/test/return_types/test_returntypes.py
@@ -20,11 +20,7 @@ project_root = os.path.dirname(os.path.dirname(current_path))
 @pytest.fixture
 def deployed_contract(w3: Web3):
     """Deploys a ReturnTypes contract."""
-    deployer = ReturnTypesContract.factory(w3=w3)
-    tx_hash = deployer.constructor().transact({"from": w3.eth.accounts[0]})
-    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-    # contractAddress not recognized for some reason, adding type ignore
-    return deployer(address=tx_receipt.contractAddress)  # type: ignore
+    return ReturnTypesContract.deploy(w3=w3, signer=w3.eth.accounts[0])
 
 
 class TestReturnTypes:

--- a/pypechain/test/return_types/types/ReturnTypesContract.py
+++ b/pypechain/test/return_types/types/ReturnTypesContract.py
@@ -934,7 +934,21 @@ class ReturnTypesContract(Contract):
     functions: ReturnTypesContractFunctions
 
     @classmethod
-    def deploy(cls, w3: Web3, signer) -> Self:
+    def deploy(cls, w3: Web3, signer: ChecksumAddress) -> Self:
+        """Deploys and instance of the contract.
+
+        Parameters
+        ----------
+        w3 : Web3
+            A web3 instance.
+        signer : ChecksumAddress
+            The address to deploy the contract from.
+
+        Returns
+        -------
+        Self
+            A deployed instance of the contract.
+        """
         deployer = cls.factory(w3=w3)
         tx_hash = deployer.constructor().transact({"from": signer})
         tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)

--- a/pypechain/test/return_types/types/ReturnTypesContract.py
+++ b/pypechain/test/return_types/types/ReturnTypesContract.py
@@ -23,17 +23,14 @@ from dataclasses import fields, is_dataclass
 from typing import Any, NamedTuple, Tuple, Type, TypeVar, cast
 
 from eth_typing import ChecksumAddress, HexStr
-
 from hexbytes import HexBytes
 from typing_extensions import Self
 from web3 import Web3
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
-
 from web3.exceptions import FallbackNotFound
 from web3.types import ABI, BlockIdentifier, CallOverride, TxParams
 
-
-from .ReturnTypesTypes import SimpleStruct, InnerStruct, NestedStruct
+from .ReturnTypesTypes import InnerStruct, NestedStruct, SimpleStruct
 
 T = TypeVar("T")
 
@@ -583,8 +580,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "simpleStruct",
@@ -592,10 +597,24 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "bool",
+                                    "name": "boolVal",
+                                    "type": "bool",
+                                }
+                            ],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -618,8 +637,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "struct1",
@@ -645,8 +672,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "simpleStruct",
@@ -654,10 +689,24 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "bool",
+                                    "name": "boolVal",
+                                    "type": "bool",
+                                }
+                            ],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -707,10 +756,24 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "bool",
+                                    "name": "boolVal",
+                                    "type": "bool",
+                                }
+                            ],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -730,8 +793,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -747,8 +818,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -756,10 +835,24 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "bool",
+                                    "name": "boolVal",
+                                    "type": "bool",
+                                }
+                            ],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -779,8 +872,16 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -788,8 +889,16 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
-                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
-                        {"internalType": "string", "name": "strVal", "type": "string"},
+                        {
+                            "internalType": "uint256",
+                            "name": "intVal",
+                            "type": "uint256",
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "strVal",
+                            "type": "string",
+                        },
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -823,6 +932,14 @@ class ReturnTypesContract(Contract):
             print("Fallback function not found. Continuing...")
 
     functions: ReturnTypesContractFunctions
+
+    @classmethod
+    def deploy(cls, w3: Web3, signer) -> Self:
+        deployer = cls.factory(w3=w3)
+        tx_hash = deployer.constructor().transact({"from": signer})
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        deployed_contract = deployer(address=tx_receipt.contractAddress)  # type: ignore
+        return deployed_contract
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:


### PR DESCRIPTION
- add type-hints
- add deploy method
- use deploy method in test
- use deployer in returntypes tests
