### PR TITLE
Fix generated import statements

### DIFF
--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -111,8 +111,8 @@ def parse_arguments(argv: Sequence[str] | None = None) -> Args:
     parser.add_argument(
         "--line_length",
         type=int,
-        default=80,
-        help="Optional argument for the output file's maximum line length. Defaults to 80.",
+        default=120,
+        help="Optional argument for the output file's maximum line length. Defaults to 120.",
     )
 
     # Use system arguments if none were passed

--- a/pypechain/render/main.py
+++ b/pypechain/render/main.py
@@ -1,6 +1,7 @@
 """Functions to render Python files from an abi usng a jinja2 template."""
 
 import os
+import subprocess
 from pathlib import Path
 
 from pypechain.render.contract import render_contract_file
@@ -9,7 +10,7 @@ from pypechain.utilities.file import write_string_to_file
 from pypechain.utilities.format import apply_black_formatting
 
 
-def render_files(abi_file_path: str, output_dir: str, line_length: int) -> list[str]:
+def render_files(abi_file_path: str, output_dir: str, line_length: int = 120) -> list[str]:
     """Processes a single JSON file to generate class and types files."""
 
     # get names
@@ -19,21 +20,39 @@ def render_files(abi_file_path: str, output_dir: str, line_length: int) -> list[
     contract_name = os.path.splitext(filename)[0]
     contract_path = output_path.joinpath(f"{contract_name}")
 
-    # render the code
+    # render the code for each file
     rendered_contract_code = render_contract_file(contract_name, file_path)
-    # TODO: if there are no types generated, then this should return None
     rendered_types_code = render_types_file(contract_name, file_path)
 
+    # keep track of file names to return
     file_names: list[str] = []
-    # Format the generated code using Black and rite the code to file
-    formatted_contract_code = apply_black_formatting(rendered_contract_code, line_length)
-    write_string_to_file(f"{contract_path}Contract.py", formatted_contract_code)
+
+    contract_file_path = Path(f"{contract_path}Contract.py")
+    write_string_to_file(contract_file_path, rendered_contract_code)
+    format_file(contract_file_path)
     file_names.append(f"{contract_name}Contract")
 
     # TODO: write tests for this conditional write.
     if rendered_types_code:
+        types_file_path = Path(f"{contract_path}Types.py")
         formatted_types_code = apply_black_formatting(rendered_types_code, line_length)
-        write_string_to_file(f"{contract_path}Types.py", formatted_types_code)
+        write_string_to_file(types_file_path, formatted_types_code)
+        format_file(types_file_path)
         file_names.append(f"{contract_name}Types")
 
     return file_names
+
+
+def format_file(file_path: Path, line_length: int = 120) -> None:
+    """Formats a file with isort and black.
+
+    Parameters
+    ----------
+    file_path : Path
+        The file to be formatted.
+    line_length : int, optional
+        Black's line-length config option.
+    """
+
+    subprocess.run(f"isort {file_path}", shell=True, check=True)
+    subprocess.run(f"black --line-length={line_length} {file_path}", shell=True, check=True)

--- a/pypechain/test/events/types/EventsContract.py
+++ b/pypechain/test/events/types/EventsContract.py
@@ -244,10 +244,7 @@ class EventsEventAContractEvent(ContractEvent):
         return cast(
             Iterable[EventData],
             super().get_logs(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                block_hash=block_hash,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, block_hash=block_hash
             ),
         )
 
@@ -262,10 +259,7 @@ class EventsEventAContractEvent(ContractEvent):
         return cast(
             Iterable[EventData],
             super().get_logs(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                block_hash=block_hash,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, block_hash=block_hash
             ),
         )
 
@@ -281,11 +275,7 @@ class EventsEventAContractEvent(ContractEvent):
         return cast(
             LogFilter,
             super().create_filter(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                address=address,
-                topics=topics,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, address=address, topics=topics
             ),
         )
 
@@ -302,11 +292,7 @@ class EventsEventAContractEvent(ContractEvent):
         return cast(
             LogFilter,
             super().create_filter(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                address=address,
-                topics=topics,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, address=address, topics=topics
             ),
         )
 
@@ -334,10 +320,7 @@ class EventsEventBContractEvent(ContractEvent):
         return cast(
             Iterable[EventData],
             super().get_logs(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                block_hash=block_hash,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, block_hash=block_hash
             ),
         )
 
@@ -352,10 +335,7 @@ class EventsEventBContractEvent(ContractEvent):
         return cast(
             Iterable[EventData],
             super().get_logs(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                block_hash=block_hash,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, block_hash=block_hash
             ),
         )
 
@@ -371,11 +351,7 @@ class EventsEventBContractEvent(ContractEvent):
         return cast(
             LogFilter,
             super().create_filter(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                address=address,
-                topics=topics,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, address=address, topics=topics
             ),
         )
 
@@ -392,11 +368,7 @@ class EventsEventBContractEvent(ContractEvent):
         return cast(
             LogFilter,
             super().create_filter(
-                argument_filters=argument_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-                address=address,
-                topics=topics,
+                argument_filters=argument_filters, fromBlock=fromBlock, toBlock=toBlock, address=address, topics=topics
             ),
         )
 
@@ -417,23 +389,11 @@ class EventsContractEvents(ContractEvents):
         super().__init__(abi, w3, address)
         self.EventA = cast(
             EventsEventAContractEvent,
-            EventsEventAContractEvent.factory(
-                "EventA",
-                w3=w3,
-                contract_abi=abi,
-                address=address,
-                event_name="EventA",
-            ),
+            EventsEventAContractEvent.factory("EventA", w3=w3, contract_abi=abi, address=address, event_name="EventA"),
         )
         self.EventB = cast(
             EventsEventBContractEvent,
-            EventsEventBContractEvent.factory(
-                "EventB",
-                w3=w3,
-                contract_abi=abi,
-                address=address,
-                event_name="EventB",
-            ),
+            EventsEventBContractEvent.factory("EventB", w3=w3, contract_abi=abi, address=address, event_name="EventB"),
         )
 
 
@@ -443,18 +403,8 @@ events_abi: ABI = cast(
         {
             "anonymous": False,
             "inputs": [
-                {
-                    "indexed": True,
-                    "internalType": "address",
-                    "name": "who",
-                    "type": "address",
-                },
-                {
-                    "indexed": False,
-                    "internalType": "uint256",
-                    "name": "value",
-                    "type": "uint256",
-                },
+                {"indexed": True, "internalType": "address", "name": "who", "type": "address"},
+                {"indexed": False, "internalType": "uint256", "name": "value", "type": "uint256"},
             ],
             "name": "EventA",
             "type": "event",

--- a/pypechain/test/events/types/EventsTypes.py
+++ b/pypechain/test/events/types/EventsTypes.py
@@ -17,11 +17,7 @@ https://github.com/delvtech/pypechain """
 # pylint: disable=no-else-return
 from __future__ import annotations
 
-
-from web3.types import ABIEvent
-
-from web3.types import ABIEventParams
-
+from web3.types import ABIEvent, ABIEventParams
 
 EventA = ABIEvent(
     anonymous=False,

--- a/pypechain/test/overloading/types/OverloadedMethodsContract.py
+++ b/pypechain/test/overloading/types/OverloadedMethodsContract.py
@@ -275,11 +275,7 @@ overloadedmethods_abi: ABI = cast(
             ],
             "name": "doSomething",
             "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "int_input",
-                    "type": "uint256",
-                },
+                {"internalType": "uint256", "name": "int_input", "type": "uint256"},
                 {"internalType": "string", "name": "", "type": "string"},
             ],
             "stateMutability": "pure",

--- a/pypechain/test/overloading/types/OverloadedMethodsContract.py
+++ b/pypechain/test/overloading/types/OverloadedMethodsContract.py
@@ -22,16 +22,13 @@ from __future__ import annotations
 from dataclasses import fields, is_dataclass
 from typing import Any, NamedTuple, Tuple, Type, TypeVar, cast, overload
 
-
 from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
 from typing_extensions import Self
 from web3 import Web3
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
-
 from web3.exceptions import FallbackNotFound
 from web3.types import ABI, BlockIdentifier, CallOverride, TxParams
-
 
 T = TypeVar("T")
 

--- a/pypechain/test/return_types/types/ReturnTypesContract.py
+++ b/pypechain/test/return_types/types/ReturnTypesContract.py
@@ -22,18 +22,15 @@ from __future__ import annotations
 from dataclasses import fields, is_dataclass
 from typing import Any, NamedTuple, Tuple, Type, TypeVar, cast
 
-
 from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
 from typing_extensions import Self
 from web3 import Web3
 from web3.contract.contract import Contract, ContractFunction, ContractFunctions
-
 from web3.exceptions import FallbackNotFound
 from web3.types import ABI, BlockIdentifier, CallOverride, TxParams
 
-
-from .ReturnTypesTypes import SimpleStruct, InnerStruct, NestedStruct
+from .ReturnTypesTypes import InnerStruct, NestedStruct, SimpleStruct
 
 T = TypeVar("T")
 

--- a/pypechain/test/return_types/types/ReturnTypesContract.py
+++ b/pypechain/test/return_types/types/ReturnTypesContract.py
@@ -580,16 +580,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "simpleStruct",
@@ -597,24 +589,10 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
-                        {
-                            "components": [
-                                {
-                                    "internalType": "bool",
-                                    "name": "boolVal",
-                                    "type": "bool",
-                                }
-                            ],
+                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -637,16 +615,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "struct1",
@@ -672,16 +642,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "simpleStruct",
@@ -689,24 +651,10 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
-                        {
-                            "components": [
-                                {
-                                    "internalType": "bool",
-                                    "name": "boolVal",
-                                    "type": "bool",
-                                }
-                            ],
+                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -756,24 +704,10 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
-                        {
-                            "components": [
-                                {
-                                    "internalType": "bool",
-                                    "name": "boolVal",
-                                    "type": "bool",
-                                }
-                            ],
+                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -793,16 +727,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -818,16 +744,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -835,24 +753,10 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                         {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
-                        {
-                            "components": [
-                                {
-                                    "internalType": "bool",
-                                    "name": "boolVal",
-                                    "type": "bool",
-                                }
-                            ],
+                            "components": [{"internalType": "bool", "name": "boolVal", "type": "bool"}],
                             "internalType": "struct ReturnTypes.InnerStruct",
                             "name": "innerStruct",
                             "type": "tuple",
@@ -872,16 +776,8 @@ returntypes_abi: ABI = cast(
             "outputs": [
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",
@@ -889,16 +785,8 @@ returntypes_abi: ABI = cast(
                 },
                 {
                     "components": [
-                        {
-                            "internalType": "uint256",
-                            "name": "intVal",
-                            "type": "uint256",
-                        },
-                        {
-                            "internalType": "string",
-                            "name": "strVal",
-                            "type": "string",
-                        },
+                        {"internalType": "uint256", "name": "intVal", "type": "uint256"},
+                        {"internalType": "string", "name": "strVal", "type": "string"},
                     ],
                     "internalType": "struct ReturnTypes.SimpleStruct",
                     "name": "",

--- a/pypechain/test/return_types/types/ReturnTypesTypes.py
+++ b/pypechain/test/return_types/types/ReturnTypesTypes.py
@@ -17,7 +17,6 @@ https://github.com/delvtech/pypechain """
 # pylint: disable=no-else-return
 from __future__ import annotations
 
-
 from dataclasses import dataclass
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pypechain = "pypechain.main:main"
 [project.optional-dependencies]
 # This flag installs all dependencies and should be ran when installing this package
 all = ["pypechain[base,build,test]"]
-base = ["black", "jinja2", "web3"]
+base = ["black", "isort", "jinja2", "web3"]
 build = ["build", "setuptools", "wheel", "twine"]
 test = ["pytest", "pytest-snapshot", "pyright", "pylint", "coverage", "isort"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pypechain = "pypechain.main:main"
 all = ["pypechain[base,build,test]"]
 base = ["black", "jinja2", "web3"]
 build = ["build", "setuptools", "wheel", "twine"]
-test = ["pytest", "pytest-snapshot", "pyright", "pylint", "coverage"]
+test = ["pytest", "pytest-snapshot", "pyright", "pylint", "coverage", "isort"]
 
 [project.urls]
 "Homepage" = "https://github.com/delvtech/pypechain"


### PR DESCRIPTION
Uses isort to sort the import statements of the generated files.  This is really nice because it will automatically clean up unused imports and combine duplicated imports.  Now we don't need any logic in the import section, we can just list everything we might use and let isort clean it up.