### PR TITLE
Improve pypechain import

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,8 @@ from web3 import Web3
 from web3.middleware import geth_poa
 from web3.types import RPCEndpoint
 
+from pypechain import pypechain
+
 # pylint: disable=redefined-outer-name
 
 # IMPORTANT NOTE!!!!!
@@ -181,5 +183,5 @@ def process_contracts(request):
                 with open(output_file, "w", encoding="utf-8") as file:
                     json.dump(data, file, ensure_ascii=False, indent=2)
 
-    # Run the pypechain module after processing all contracts
-    subprocess.run(f"pypechain {test_dir}/abis --output_dir={test_dir}/types", shell=True, check=True)
+    # # Run the pypechain module after processing all contracts
+    pypechain(f"{test_dir}/abis", f"{test_dir}/types")

--- a/pypechain/__init__.py
+++ b/pypechain/__init__.py
@@ -3,3 +3,4 @@
 # This tool is meant to be used as a command line tool.  It is exported here for testing.  Do not
 # rely on this being available in the future.
 from .main import main as pypechain_cli
+from .main import pypechain

--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -35,7 +35,7 @@ def pypechain(abi_file_path: str, output_dir: str = "pypechain_types", line_leng
     abi_file_path : str
         Path to the abi JSON file.
     output_dir: str, optional
-        Path to the directory where files will be generated.
+        Path to the directory where files will be generated. Defaults to 'pypechain_types'.
     line_length : int, optional
         Optional argument for the output file's maximum line length. Defaults to 120.
     """

--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -16,6 +16,18 @@ from pypechain.render.main import render_files
 
 
 def main(argv: Sequence[str] | None = None) -> None:
+    """Main entrypoint for pypechain cli.
+
+    Arguments
+    ---------
+    argv : Sequence[str] | None, optional
+        _description_, by default None
+    """
+    abi_file_path, output_dir, line_length = parse_arguments(argv)
+    pypechain(abi_file_path, output_dir, line_length)
+
+
+def pypechain(abi_file_path: str, output_dir: str, line_length: int = 120):
     """Generates class files for a given abi.
 
     Arguments
@@ -25,10 +37,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     output_dir: str
         Path to the directory where files will be generated.
     line_length : int
-        Optional argument for the output file's maximum line length. Defaults to 80.
+        Optional argument for the output file's maximum line length. Defaults to 120.
     """
-
-    abi_file_path, output_dir, line_length = parse_arguments(argv)
 
     # TODO: move to end of main() so that files aren't cleared if something breaks during script
     # execution. Create/clear the output directory

--- a/pypechain/main.py
+++ b/pypechain/main.py
@@ -27,16 +27,16 @@ def main(argv: Sequence[str] | None = None) -> None:
     pypechain(abi_file_path, output_dir, line_length)
 
 
-def pypechain(abi_file_path: str, output_dir: str, line_length: int = 120):
+def pypechain(abi_file_path: str, output_dir: str = "pypechain_types", line_length: int = 120):
     """Generates class files for a given abi.
 
     Arguments
     ---------
     abi_file_path : str
         Path to the abi JSON file.
-    output_dir: str
+    output_dir: str, optional
         Path to the directory where files will be generated.
-    line_length : int
+    line_length : int, optional
         Optional argument for the output file's maximum line length. Defaults to 120.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "pypechain"
-version = "0.0.23"
+version = "0.0.24"
 authors = [
     { name = "Matthew Brown", email = "matt@delv.tech" },
     { name = "Dylan Paiton", email = "dylan@delv.tech" },


### PR DESCRIPTION
Allows for this import style and usage:
```python
from pypechain import pypechain

abi_dir = "./abis"
out_dir = "./types"
line_length = 80
pypechain(abi_dir, out_dir, line_length)
```