### PR TITLE
Don't override existing contracts. Version bump to v0.0.36

### DIFF
--- a/pypechain/render/contract.py
+++ b/pypechain/render/contract.py
@@ -152,7 +152,16 @@ def _add_events(contract_infos: dict[str, ContractInfo], events: EventInfo | lis
     for event in events:
         info = contract_infos.get(contract_name)
         if info:
-            info.events[event.name] = event
+            # Sanity check, if this event already exists, we compare the two and ensure
+            # it's the same event
+            if event.name in info.events:
+                assert info.events[event.name] == event, (
+                    "Existing event for contract "
+                    f"{contract_name}:{event.name} {info.events[event.name]} "
+                    f"does not match defined event {event}."
+                )
+            else:
+                info.events[event.name] = event
         else:
             contract_infos[contract_name] = ContractInfo(
                 abi=[],
@@ -184,7 +193,16 @@ def _add_errors(contract_infos: dict[str, ContractInfo], errors: ErrorInfo | lis
     for error in errors:
         info = contract_infos.get(contract_name)
         if info:
-            info.errors[error.name] = error
+            # Sanity check, if this event already exists, we compare the two and ensure
+            # it's the same event
+            if error.name in info.errors:
+                assert info.errors[error.name] == error, (
+                    "Existing error for contract "
+                    f"{contract_name}:{error.name} {info.errors[error.name]} "
+                    f"does not match defined event {error}."
+                )
+            else:
+                info.errors[error.name] = error
         else:
             contract_infos[contract_name] = ContractInfo(
                 abi=[],

--- a/pypechain/render/contract.py
+++ b/pypechain/render/contract.py
@@ -156,13 +156,10 @@ def _add_events(contract_infos: dict[str, ContractInfo], events: EventInfo | lis
     for event in events:
         info = contract_infos.get(contract_name)
         if info:
-            # Sanity check, if this event already exists, we compare the two and ensure
-            # it's the same event
+            # TODO events can be overloaded with different types.
+            # We don't support this yet.
+            # https://github.com/delvtech/pypechain/issues/124
             if event.name in info.events:
-                # TODO events can be overloaded with different types.
-                # We don't support this yet.
-                # https://github.com/delvtech/pypechain/issues/124
-
                 # We use the global flag to only warn once
                 global OVERLOAD_EVENT_WARN  # pylint: disable=global-statement
                 if not OVERLOAD_EVENT_WARN and info.events[event.name] != event:

--- a/pypechain/render/contract.py
+++ b/pypechain/render/contract.py
@@ -204,8 +204,8 @@ def _add_errors(contract_infos: dict[str, ContractInfo], errors: ErrorInfo | lis
     for error in errors:
         info = contract_infos.get(contract_name)
         if info:
-            # Sanity check, if this event already exists, we compare the two and ensure
-            # it's the same event
+            # Sanity check, if this error already exists, we compare the two and ensure
+            # it's the same error
             if error.name in info.errors:
                 assert info.errors[error.name] == error, (
                     "Existing error for contract "

--- a/pypechain/utilities/abi.py
+++ b/pypechain/utilities/abi.py
@@ -669,8 +669,6 @@ def load_abi_infos_from_file(file_path: Path) -> list[AbiInfo]:
 
         if is_hardhat_json(json_file):
             abi = get_abi_from_json(json_file)
-            if len(abi) == 0:
-                raise ValueError("Hardhat ABI field is empty.")
             bytecode = get_bytecode_from_json(json_file)
             # hardhat jsons have the contract name as a field.
             contract_name = json_file.get("contractName")
@@ -678,8 +676,6 @@ def load_abi_infos_from_file(file_path: Path) -> list[AbiInfo]:
 
         if is_foundry_json(json_file):
             abi = get_abi_from_json(json_file)
-            if len(abi) == 0:
-                raise ValueError("Foundry ABI field is empty.")
             bytecode = get_bytecode_from_json(json_file)
             # foundry saves contracts to self-named files.
             contract_name = file_path.name.removesuffix(".json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "pypechain"
-version = "0.0.35"
+version = "0.0.36"
 authors = [
     { name = "Matthew Brown", email = "matt@delv.tech" },
     { name = "Dylan Paiton", email = "dylan@delv.tech" },


### PR DESCRIPTION
- Fixes an issue where a contract's structs gets overwritten based on the order of what contracts gets read first.
- Reverts https://github.com/delvtech/pypechain/pull/121, as this fix should handle empty abis.
- Adds a warning that prints once when overloaded events are being used.
- Version bump to v0.0.36