### PR TITLE
Adding makefile to help build test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build build-test build-test-sol build-test-types clean
+
+build-test:
+	make build-test-sol
+	make build-test-types
+	make build-test-format-abi
+
+build-test-sol:
+	sh scripts/rebuild_sol.sh	
+
+build-test-format-abi:
+	python scripts/format_json_dir.py
+
+build-test-types:
+	sh scripts/regenerate_types.sh
+
+clean:
+	rm -rf example/abis/* && rm -rf example/types/* && rm -rf pypechain/test/*/abis/* && rm -rf pypechain/test/*/types/*
+
+
+

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ We use pytest in our pypechain tests. Pytest, when ran locally, automatically co
 using [Foundry](https://book.getfoundry.sh/getting-started/installation), as well as running 
 pypechain on the output abis.
 
-If you run into issues during pytest, run `sh scripts/regenerate_types.sh`.
+If you run into issues during pytest, run `make clean; make build-test` to rebuild all solidity
+and pypechain types in tests.
 
 We also use [`pytest-snapshot`](https://pypi.org/project/pytest-snapshot/) for some tests to ensure
 rendered files are as expected. If any changes are made to rendering that results in failures in snapshots, 

--- a/example/types/ExampleContract.py
+++ b/example/types/ExampleContract.py
@@ -1065,7 +1065,7 @@ class ExampleContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructor_args: ConstructorArgs) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -1109,7 +1109,7 @@ class ExampleContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -1121,7 +1121,7 @@ class ExampleContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ExampleContractFunctions(example_abi, w3, None)

--- a/pypechain/templates/contract.py/contract.py.jinja2
+++ b/pypechain/templates/contract.py/contract.py.jinja2
@@ -97,7 +97,7 @@ class {{contract_name}}Contract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress{{', constructor_args: ConstructorArgs' if has_constructor_args else ''}}{{', link_references: LinkReferences' if has_link_references else ''}}) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -139,7 +139,7 @@ class {{contract_name}}Contract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -151,7 +151,7 @@ class {{contract_name}}Contract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = {{contract_name}}ContractFunctions({{contract_name | lower}}_abi, w3, None)

--- a/pypechain/test/deploy_linking/types/ContractContract.py
+++ b/pypechain/test/deploy_linking/types/ContractContract.py
@@ -174,7 +174,7 @@ class ContractContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, link_references: LinkReferences) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -216,7 +216,7 @@ class ContractContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -228,7 +228,7 @@ class ContractContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ContractContractFunctions(contract_abi, w3, None)

--- a/pypechain/test/deploy_linking/types/MyLibraryContract.py
+++ b/pypechain/test/deploy_linking/types/MyLibraryContract.py
@@ -159,7 +159,7 @@ class MyLibraryContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -201,7 +201,7 @@ class MyLibraryContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -213,7 +213,7 @@ class MyLibraryContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = MyLibraryContractFunctions(mylibrary_abi, w3, None)

--- a/pypechain/test/deployment/types/ConstructorNoArgsContract.py
+++ b/pypechain/test/deployment/types/ConstructorNoArgsContract.py
@@ -196,7 +196,7 @@ class ConstructorNoArgsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -238,7 +238,7 @@ class ConstructorNoArgsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -250,7 +250,7 @@ class ConstructorNoArgsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ConstructorNoArgsContractFunctions(constructornoargs_abi, w3, None)

--- a/pypechain/test/deployment/types/ConstructorWithArgsContract.py
+++ b/pypechain/test/deployment/types/ConstructorWithArgsContract.py
@@ -205,7 +205,7 @@ class ConstructorWithArgsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructor_args: ConstructorArgs) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -249,7 +249,7 @@ class ConstructorWithArgsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -261,7 +261,7 @@ class ConstructorWithArgsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ConstructorWithArgsContractFunctions(constructorwithargs_abi, w3, None)

--- a/pypechain/test/deployment/types/ConstructorWithStructArgsContract.py
+++ b/pypechain/test/deployment/types/ConstructorWithStructArgsContract.py
@@ -271,7 +271,7 @@ class ConstructorWithStructArgsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructor_args: ConstructorArgs) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -315,7 +315,7 @@ class ConstructorWithStructArgsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -327,7 +327,7 @@ class ConstructorWithStructArgsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ConstructorWithStructArgsContractFunctions(constructorwithstructargs_abi, w3, None)

--- a/pypechain/test/deployment/types/NoConstructorContract.py
+++ b/pypechain/test/deployment/types/NoConstructorContract.py
@@ -195,7 +195,7 @@ class NoConstructorContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -237,7 +237,7 @@ class NoConstructorContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -249,7 +249,7 @@ class NoConstructorContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = NoConstructorContractFunctions(noconstructor_abi, w3, None)

--- a/pypechain/test/errors/types/ErrorsContract.py
+++ b/pypechain/test/errors/types/ErrorsContract.py
@@ -425,7 +425,7 @@ class ErrorsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -467,7 +467,7 @@ class ErrorsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -479,7 +479,7 @@ class ErrorsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ErrorsContractFunctions(errors_abi, w3, None)

--- a/pypechain/test/events/types/EventsContract.py
+++ b/pypechain/test/events/types/EventsContract.py
@@ -440,7 +440,7 @@ class EventsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -482,7 +482,7 @@ class EventsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -494,7 +494,7 @@ class EventsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = EventsContractFunctions(events_abi, w3, None)

--- a/pypechain/test/overloading/types/OverloadedMethodsContract.py
+++ b/pypechain/test/overloading/types/OverloadedMethodsContract.py
@@ -295,7 +295,7 @@ class OverloadedMethodsContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -337,7 +337,7 @@ class OverloadedMethodsContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -349,7 +349,7 @@ class OverloadedMethodsContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = OverloadedMethodsContractFunctions(overloadedmethods_abi, w3, None)

--- a/pypechain/test/return_types/types/ReturnTypesContract.py
+++ b/pypechain/test/return_types/types/ReturnTypesContract.py
@@ -845,7 +845,7 @@ class ReturnTypesContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -887,7 +887,7 @@ class ReturnTypesContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -899,7 +899,7 @@ class ReturnTypesContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = ReturnTypesContractFunctions(returntypes_abi, w3, None)

--- a/pypechain/test/structs/types/StructsAContract.py
+++ b/pypechain/test/structs/types/StructsAContract.py
@@ -287,7 +287,7 @@ class StructsAContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -329,7 +329,7 @@ class StructsAContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -341,7 +341,7 @@ class StructsAContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = StructsAContractFunctions(structsa_abi, w3, None)

--- a/pypechain/test/structs/types/StructsBContract.py
+++ b/pypechain/test/structs/types/StructsBContract.py
@@ -213,7 +213,7 @@ class StructsBContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -255,7 +255,7 @@ class StructsBContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -267,7 +267,7 @@ class StructsBContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = StructsBContractFunctions(structsb_abi, w3, None)

--- a/pypechain/test/structs/types/StructsCContract.py
+++ b/pypechain/test/structs/types/StructsCContract.py
@@ -243,7 +243,7 @@ class StructsCContract(Contract):
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress) -> Self:
-        """Deploys and instance of the contract.
+        """Deploys an instance of the contract.
 
         Parameters
         ----------
@@ -285,7 +285,7 @@ class StructsCContract(Contract):
 
     @classmethod
     def factory(cls, w3: Web3, class_name: str | None = None, **kwargs: Any) -> Type[Self]:
-        """Deploys and instance of the contract.
+        """Initializes the contract object.
 
         Parameters
         ----------
@@ -297,7 +297,7 @@ class StructsCContract(Contract):
         Returns
         -------
         Self
-            A deployed instance of the contract.
+            An instance of the contract class.
         """
         contract = super().factory(w3, class_name, **kwargs)
         contract.functions = StructsCContractFunctions(structsc_abi, w3, None)

--- a/scripts/format_json_dir.py
+++ b/scripts/format_json_dir.py
@@ -1,0 +1,25 @@
+"""Script to recursively format json files under a directory."""
+
+import json
+import os
+
+
+def _format_json_dir(json_dir):
+    for root, dirs, files in os.walk(json_dir):
+        # Format any outer json files
+        for file in files:
+            if file.endswith(".json"):
+                json_file = os.path.join(root, file)
+                # Format the JSON file
+                with open(json_file, "r", encoding="utf-8") as file:
+                    data = json.load(file)
+                with open(json_file, "w", encoding="utf-8") as file:
+                    json.dump(data, file, ensure_ascii=False, indent=2)
+
+        for d in dirs:
+            _format_json_dir(d)
+
+
+if __name__ == "__main__":
+    _format_json_dir("example/abis/")
+    _format_json_dir("pypechain/test/")

--- a/scripts/rebuild_sol.sh
+++ b/scripts/rebuild_sol.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run the command in the example/ directory
+echo "Running command in example/ directory:"
+forge build example/contracts -o example/abis
+
+# Run the command in every directory in pypechain/test/
+echo "Running command in pypechain/test/ directories:"
+for dir in pypechain/test/*; do
+    if [ -d "$dir" ]; then
+        echo "Processing $dir..."
+        forge build "$dir/contracts" -o "$dir/abis"
+    fi
+done


### PR DESCRIPTION
`make build-test` runs everything to recompile solidity and run pypechain on test files. Eventually, we can even remove these files from the repo and build everything from scratch in CI.

Includes fixes to docstrings for `Contract.factory`